### PR TITLE
ci: increase TKE checkin BVT timeout

### DIFF
--- a/.github/workflows/merge-trigger-tke.yaml
+++ b/.github/workflows/merge-trigger-tke.yaml
@@ -304,7 +304,7 @@ jobs:
           echo "$JAVA_HOME/bin" >> $GITHUB_PATH
       - name: Generate MO-Tester Config and Start BVT Test
         if: ${{ always() && !cancelled() }}
-        timeout-minutes: 50
+        timeout-minutes: 60
         run: |
           export LC_ALL="C.UTF-8"
           locale


### PR DESCRIPTION
## Summary
- Increase the MO Checkin Regression On TKE BVT step timeout from 50 minutes to 60 minutes.

## Context
Recent checkin regression BVT runs often finish close to the 50-minute limit, with several failures caused by the GitHub step timeout rather than SQL failures or MO panics. This gives the BVT step a small buffer for normal TKE/runtime variance.

## Test
- Not run; workflow timeout-only change.