### PR TITLE
fix(e2e-upgrade): launch head with v1 legacy-DISK config on existing clusters

### DIFF
--- a/.github/workflows/e2e-upgrade.yaml
+++ b/.github/workflows/e2e-upgrade.yaml
@@ -51,6 +51,13 @@ jobs:
           echo "[cn.txn]" >> ./etc/launch/cn.toml
           echo "  enable-leak-check = 1" >> ./etc/launch/cn.toml
           echo '  max-active-ages = "2m"'>> ./etc/launch/cn.toml
+          # Mirror the cn.txn settings into the legacy v1/launch (DISK) config,
+          # which the upgrade run launches with when ./etc/v1/launch is present.
+          if [ -f ./etc/v1/launch/cn.toml ]; then
+            echo "[cn.txn]" >> ./etc/v1/launch/cn.toml
+            echo "  enable-leak-check = 1" >> ./etc/v1/launch/cn.toml
+            echo '  max-active-ages = "2m"'>> ./etc/v1/launch/cn.toml
+          fi
 
       - name: Build MatrixOne for head
         run: |
@@ -141,15 +148,19 @@ jobs:
           if [ -d "$GITHUB_WORKSPACE/head/lib" ]; then
             mv $GITHUB_WORKSPACE/head/lib .
           fi
-          echo "==============cn configuration of upstram=============="
-          cat ./etc/launch/cn.toml
-          echo "==============tn configuration of upstram=============="
-          if [[ -f ./etc/launch/dn.toml ]]; then
-            cat ./etc/launch/dn.toml     
-          else 
-            cat ./etc/launch/tn.toml     
+          # mo-data was written by the upstream binary in DISK (CRC) format.
+          # If head ships the legacy ./etc/v1/<profile> (DISK) config, launch
+          # with it so the new binary mounts the existing cluster in its
+          # original on-disk format. Fresh deploys use ./etc/<profile> (DISK-V2).
+          PROFILE=launch
+          LAUNCH_DIR=$PROFILE
+          if [ -d ./etc/v1/$PROFILE ]; then
+            LAUNCH_DIR=v1/$PROFILE
           fi
-          ./optools/run_bvt.sh $GITHUB_WORKSPACE/workspace launch;
+          echo "==============head launch dir: $LAUNCH_DIR=============="
+          echo "============== head launch configs =============="
+          cat ./etc/$LAUNCH_DIR/*.toml 2>/dev/null || true
+          ./optools/run_bvt.sh $GITHUB_WORKSPACE/workspace $LAUNCH_DIR;
           sleep 60;
       - name: Update BVT SQL Timeout for Head Branch
         run: |
@@ -267,6 +278,13 @@ jobs:
           echo "[cn.txn]" >> ./etc/launch/cn.toml
           echo "  enable-leak-check = 1" >> ./etc/launch/cn.toml
           echo '  max-active-ages = "2m"'>> ./etc/launch/cn.toml
+          # Mirror the cn.txn settings into the legacy v1/launch (DISK) config,
+          # which the upgrade run launches with when ./etc/v1/launch is present.
+          if [ -f ./etc/v1/launch/cn.toml ]; then
+            echo "[cn.txn]" >> ./etc/v1/launch/cn.toml
+            echo "  enable-leak-check = 1" >> ./etc/v1/launch/cn.toml
+            echo '  max-active-ages = "2m"'>> ./etc/v1/launch/cn.toml
+          fi
 
       - name: Build MatrixOne for head
         run: |
@@ -358,15 +376,19 @@ jobs:
           if [ -d "$GITHUB_WORKSPACE/head/lib" ]; then
             mv $GITHUB_WORKSPACE/head/lib .
           fi
-          echo "==============cn configuration of upstram=============="
-          cat ./etc/launch/cn.toml
-          echo "==============tn configuration of upstram=============="
-          if [[ -f ./etc/launch/dn.toml ]]; then
-            cat ./etc/launch/dn.toml     
-          else 
-            cat ./etc/launch/tn.toml     
+          # mo-data was written by the upstream binary in DISK (CRC) format.
+          # If head ships the legacy ./etc/v1/<profile> (DISK) config, launch
+          # with it so the new binary mounts the existing cluster in its
+          # original on-disk format. Fresh deploys use ./etc/<profile> (DISK-V2).
+          PROFILE=launch
+          LAUNCH_DIR=$PROFILE
+          if [ -d ./etc/v1/$PROFILE ]; then
+            LAUNCH_DIR=v1/$PROFILE
           fi
-          ./optools/run_bvt.sh $GITHUB_WORKSPACE/workspace launch;
+          echo "==============head launch dir: $LAUNCH_DIR=============="
+          echo "============== head launch configs =============="
+          cat ./etc/$LAUNCH_DIR/*.toml 2>/dev/null || true
+          ./optools/run_bvt.sh $GITHUB_WORKSPACE/workspace $LAUNCH_DIR;
           sleep 60;
       - name: Clone test-tool repository for Head
         uses: actions/checkout@v6

--- a/.github/workflows/e2e-upgrade.yaml
+++ b/.github/workflows/e2e-upgrade.yaml
@@ -137,6 +137,14 @@ jobs:
           mv mo-service mo-service-upstream
           mv mo-service.log upstream-mo-service.log
           rm -rf mo-data/etl
+          # Detect the on-disk format the upstream binary wrote, from its config
+          # (./etc is still the upstream config at this point). DISK-V2 present
+          # means the existing mo-data is raw; otherwise it is legacy DISK (CRC).
+          PROFILE=launch
+          UPSTREAM_V2=0
+          if grep -rq "DISK-V2" ./etc/$PROFILE 2>/dev/null; then
+            UPSTREAM_V2=1
+          fi
           rm -rf etc
           rm -rf optools
           rm -rf lib
@@ -148,16 +156,14 @@ jobs:
           if [ -d "$GITHUB_WORKSPACE/head/lib" ]; then
             mv $GITHUB_WORKSPACE/head/lib .
           fi
-          # mo-data was written by the upstream binary in DISK (CRC) format.
-          # If head ships the legacy ./etc/v1/<profile> (DISK) config, launch
-          # with it so the new binary mounts the existing cluster in its
-          # original on-disk format. Fresh deploys use ./etc/<profile> (DISK-V2).
-          PROFILE=launch
+          # Launch head with the config matching the upstream data format:
+          #   upstream DISK-V2 -> ./etc/$PROFILE      (the DISK-V2 default)
+          #   upstream DISK    -> ./etc/v1/$PROFILE   (legacy DISK, when head ships it)
           LAUNCH_DIR=$PROFILE
-          if [ -d ./etc/v1/$PROFILE ]; then
+          if [ "$UPSTREAM_V2" = "0" ] && [ -d ./etc/v1/$PROFILE ]; then
             LAUNCH_DIR=v1/$PROFILE
           fi
-          echo "==============head launch dir: $LAUNCH_DIR=============="
+          echo "==============head launch dir: $LAUNCH_DIR (upstream DISK-V2=$UPSTREAM_V2)=============="
           echo "============== head launch configs =============="
           cat ./etc/$LAUNCH_DIR/*.toml 2>/dev/null || true
           ./optools/run_bvt.sh $GITHUB_WORKSPACE/workspace $LAUNCH_DIR;
@@ -364,6 +370,14 @@ jobs:
           mv mo-service mo-service-upstream
           mv mo-service.log upstream-mo-service.log
           rm -rf mo-data/etl
+          # Detect the on-disk format the upstream binary wrote, from its config
+          # (./etc is still the upstream config at this point). DISK-V2 present
+          # means the existing mo-data is raw; otherwise it is legacy DISK (CRC).
+          PROFILE=launch
+          UPSTREAM_V2=0
+          if grep -rq "DISK-V2" ./etc/$PROFILE 2>/dev/null; then
+            UPSTREAM_V2=1
+          fi
           rm -rf etc
           rm -rf optools
           rm -rf lib
@@ -376,16 +390,14 @@ jobs:
           if [ -d "$GITHUB_WORKSPACE/head/lib" ]; then
             mv $GITHUB_WORKSPACE/head/lib .
           fi
-          # mo-data was written by the upstream binary in DISK (CRC) format.
-          # If head ships the legacy ./etc/v1/<profile> (DISK) config, launch
-          # with it so the new binary mounts the existing cluster in its
-          # original on-disk format. Fresh deploys use ./etc/<profile> (DISK-V2).
-          PROFILE=launch
+          # Launch head with the config matching the upstream data format:
+          #   upstream DISK-V2 -> ./etc/$PROFILE      (the DISK-V2 default)
+          #   upstream DISK    -> ./etc/v1/$PROFILE   (legacy DISK, when head ships it)
           LAUNCH_DIR=$PROFILE
-          if [ -d ./etc/v1/$PROFILE ]; then
+          if [ "$UPSTREAM_V2" = "0" ] && [ -d ./etc/v1/$PROFILE ]; then
             LAUNCH_DIR=v1/$PROFILE
           fi
-          echo "==============head launch dir: $LAUNCH_DIR=============="
+          echo "==============head launch dir: $LAUNCH_DIR (upstream DISK-V2=$UPSTREAM_V2)=============="
           echo "============== head launch configs =============="
           cat ./etc/$LAUNCH_DIR/*.toml 2>/dev/null || true
           ./optools/run_bvt.sh $GITHUB_WORKSPACE/workspace $LAUNCH_DIR;


### PR DESCRIPTION

matrixone's etc/launch now defaults to the checksum-free DISK-V2 backend. The upgrade test reuses the upstream-written mo-data (DISK/CRC) but swapped in head's etc, so the new binary tried to read DISK data as raw and failed in wait_system_init.

A real upgrade keeps the cluster's existing storage config. So in "Start the MO of Head Ref", launch with v1/$PROFILE when ./etc/v1/$PROFILE exists (the legacy DISK config) and the upstream config is DISK, else fall back to the original profile. The cn.txn leak-check settings are mirrored into the v1 config too. Guarded by the dir check, so PRs without etc/v1 are unaffected.