### PR TITLE
Improve coverage failure diagnostics

### DIFF
--- a/.github/workflows/utils.yaml
+++ b/.github/workflows/utils.yaml
@@ -182,6 +182,7 @@ jobs:
           echo "  enable-leak-check = 1" >> ./etc/launch/cn.toml
           echo '  max-active-ages = "2m"'>> ./etc/launch/cn.toml
       - name: Start Unit Test
+        id: ut
         timeout-minutes: 45
         run: |
           set -o pipefail
@@ -204,6 +205,27 @@ jobs:
           echo "ut start"
           CGO_CFLAGS="${CGO_CFLAGS}" CGO_LDFLAGS="${CGO_LDFLAGS}" go test -json -short -v -tags matrixone_test -p 6 -covermode=set -coverprofile=${{ env.raw_ut_coverage }} -coverpkg="${cover_pkgs}" ${test_scope} > ${{ env.ut_report }}
           echo "ut finished"
+      - name: Checkout CI repository for UT summary
+        if: ${{ failure() && !cancelled() }}
+        continue-on-error: true
+        uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.TOKEN_ACTION }}
+          repository: matrixorigin/CI
+          fetch-depth: "1"
+          path: CI
+      - name: Summarize Unit Test Failure
+        if: ${{ failure() && !cancelled() }}
+        continue-on-error: true
+        run: |
+          if [ ! -f "$GITHUB_WORKSPACE/matrixone/${{ env.ut_report }}" ]; then
+            echo "UT report not found, skip summary"
+            exit 0
+          fi
+          python "$GITHUB_WORKSPACE/CI/scripts/summarize_ut_report.py" "$GITHUB_WORKSPACE/matrixone/${{ env.ut_report }}" | tee "$GITHUB_WORKSPACE/ut-failure-summary.md"
+          if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+            cat "$GITHUB_WORKSPACE/ut-failure-summary.md" >> "$GITHUB_STEP_SUMMARY"
+          fi
       - name: Analysis Fail UT Cases
         if: ${{ failure() }}
         run: |
@@ -304,23 +326,37 @@ jobs:
           echo "====================================="
           echo ""
           
-          grep -Ev ${{ env.ut_excluded_pkg }} ${{ env.raw_ut_coverage }} > ${{ env.ut_coverage }}
-          echo "ut_coverage finished"
-          go tool cover -o ${{ env.ut_html_coverage }} -html=${{ env.ut_coverage }}
-          echo "ut_html_coverage finished"
-          rm -rf ${{ env.raw_ut_coverage }}
-          pids=$(ps -aux | grep 'mo-service' | grep -v 'grep' | awk '{print $2}')
+          if [ -f ${{ env.raw_ut_coverage }} ]; then
+            grep -Ev ${{ env.ut_excluded_pkg }} ${{ env.raw_ut_coverage }} > ${{ env.ut_coverage }}
+            echo "ut_coverage finished"
+            go tool cover -o ${{ env.ut_html_coverage }} -html=${{ env.ut_coverage }}
+            echo "ut_html_coverage finished"
+            rm -rf ${{ env.raw_ut_coverage }}
+          elif [ "${{ steps.ut.conclusion }}" = "success" ]; then
+            echo "::error::${{ env.raw_ut_coverage }} does not exist after successful UT step"
+            exit 1
+          else
+            echo "::warning::${{ env.raw_ut_coverage }} does not exist because UT did not finish successfully; skip UT coverage generation"
+          fi
+
+          pids=$(pgrep -f 'mo-service' || true)
           if [ -n "$pids" ]; then
               kill -TERM $pids
           fi
   
-          i=1 && while [ -n "$(ps -aux|grep 'mo-service' | grep -v 'grep' | awk '{print $2}')" ] && [ $i -le 300 ]; do echo "mo-service kill not finished......$i/300"; i=$(($i+1)); sleep 1s; done
+          i=1 && while pgrep -f 'mo-service' > /dev/null 2>&1 && [ $i -le 300 ]; do echo "mo-service kill not finished......$i/300"; i=$(($i+1)); sleep 1s; done
           if [ $i -gt 300 ]; then echo 'stop mo-service failed...'; exit 1; else echo 'stop mo-service successed...'; fi
-          go tool covdata textfmt -i="$GITHUB_WORKSPACE/matrixone" -o ${{ env.raw_bvt_coverage }}
-          grep -Ev ${{ env.bvt_excluded_pkg }} ${{ env.raw_bvt_coverage }} > ${{ env.bvt_coverage }}
-          echo "bvt_coverage finished"
-          go tool cover -o ${{ env.bvt_html_coverage }} -html=${{ env.bvt_coverage }}
-          echo "bvt_html_coverage finished"
+          if go tool covdata textfmt -i="$GITHUB_WORKSPACE/matrixone" -o ${{ env.raw_bvt_coverage }}; then
+            grep -Ev ${{ env.bvt_excluded_pkg }} ${{ env.raw_bvt_coverage }} > ${{ env.bvt_coverage }}
+            echo "bvt_coverage finished"
+            go tool cover -o ${{ env.bvt_html_coverage }} -html=${{ env.bvt_coverage }}
+            echo "bvt_html_coverage finished"
+          elif [ "${{ steps.bvt_on_pr_version.conclusion }}" = "success" ]; then
+            echo "::error::failed to generate BVT coverage after successful BVT step"
+            exit 1
+          else
+            echo "::warning::BVT coverage data is unavailable because BVT did not finish successfully; skip BVT coverage generation"
+          fi
           
 #          # generate sorted ut coverage file
 #          sort ut_coverage.out | uniq > ut_coverage_sort.out
@@ -336,6 +372,9 @@ jobs:
             ${{ github.workspace }}/matrixone/ut_coverage.out
             ${{ github.workspace }}/matrixone/bvt_coverage.out
             ${{ github.workspace }}/matrixone/diff.patch
+            ${{ github.workspace }}/matrixone/UT-Report.out
+            ${{ github.workspace }}/ut-failure-summary.md
+            ${{ github.workspace }}/ut-report
           retention-days: 7
       - name: Checkout for Python file
         if: ${{ always() && !cancelled() }}

--- a/scripts/summarize_ut_report.py
+++ b/scripts/summarize_ut_report.py
@@ -1,0 +1,176 @@
+import argparse
+import collections
+import json
+from pathlib import Path
+
+
+def is_panic_like(output):
+    lowered = output.lower()
+    return (
+        "panic:" in lowered
+        or "fatal error:" in lowered
+        or "index out of range" in lowered
+        or "data race" in lowered
+    )
+
+
+def append_tail(buffers, key, value, limit):
+    if key not in buffers:
+        buffers[key] = collections.deque(maxlen=limit)
+    buffers[key].append(value)
+
+
+def summarize(report_path, max_output_lines, max_build_failures, max_test_failures, max_panic_lines):
+    actions = collections.Counter()
+    build_failures = []
+    test_failures = []
+    panic_like_count = 0
+    malformed = 0
+
+    with report_path.open(errors="replace") as report:
+        for line_no, line in enumerate(report, 1):
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                malformed += 1
+                continue
+
+            action = event.get("Action")
+            actions[action] += 1
+            package = event.get("Package") or event.get("ImportPath") or "<unknown>"
+            test = event.get("Test")
+            output = event.get("Output")
+
+            if action == "output" and output is not None and is_panic_like(output):
+                panic_like_count += 1
+
+            if action == "build-fail":
+                build_failures.append((line_no, package))
+            elif action == "fail":
+                test_failures.append((line_no, package, test, event.get("Elapsed")))
+
+    failed_packages = {package for _, package in build_failures}
+    failed_packages.update(package for _, package, _, _ in test_failures)
+    failed_tests = {(package, test) for _, package, test, _ in test_failures if test}
+    build_outputs = {}
+    package_outputs = {}
+    test_outputs = {}
+    panic_like = []
+
+    with report_path.open(errors="replace") as report:
+        for line_no, line in enumerate(report, 1):
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+            action = event.get("Action")
+            package = event.get("Package") or event.get("ImportPath") or "<unknown>"
+            test = event.get("Test")
+            output = event.get("Output")
+            if output is None:
+                continue
+            output = output.rstrip("\n")
+
+            if action == "build-output" and package in failed_packages:
+                append_tail(build_outputs, package, output, max_output_lines)
+            elif action == "output":
+                if package in failed_packages:
+                    append_tail(package_outputs, package, output, max_output_lines)
+                if (package, test) in failed_tests:
+                    append_tail(test_outputs, (package, test), output, max_output_lines)
+
+                if is_panic_like(output) and (not failed_packages or package in failed_packages):
+                    if len(panic_like) < max_panic_lines:
+                        panic_like.append((line_no, package, test, output))
+
+    print("# Unit Test Failure Summary")
+    print()
+    print(f"- report: `{report_path}`")
+    print(f"- events: `{dict(actions)}`")
+    if malformed:
+        print(f"- malformed json lines: `{malformed}`")
+    print(f"- build failures: `{len(build_failures)}`")
+    print(f"- failed test/package events: `{len(test_failures)}`")
+    if panic_like_count:
+        print(f"- panic-like output lines: `{panic_like_count}`")
+    print()
+
+    if build_failures:
+        print("## Build Failures")
+        print()
+        for line_no, package in build_failures[:max_build_failures]:
+            print(f"### {package}")
+            print(f"- event line: `{line_no}`")
+            lines = list(build_outputs.get(package, []))
+            if lines:
+                print("```text")
+                print("\n".join(lines))
+                print("```")
+            else:
+                print("_No build output was recorded for this package._")
+            print()
+        if len(build_failures) > max_build_failures:
+            print(f"_Omitted {len(build_failures) - max_build_failures} additional build failures._")
+            print()
+
+    if test_failures:
+        print("## Failed Tests And Packages")
+        print()
+        for line_no, package, test, elapsed in test_failures[:max_test_failures]:
+            name = test or "<package>"
+            print(f"### {package} / {name}")
+            print(f"- event line: `{line_no}`")
+            if elapsed is not None:
+                print(f"- elapsed: `{elapsed}`")
+            lines = test_outputs.get((package, test), []) if test else package_outputs.get(package, [])
+            lines = list(lines)
+            if lines:
+                print("```text")
+                print("\n".join(lines))
+                print("```")
+            else:
+                print("_No test output was recorded for this failure event._")
+            print()
+        if len(test_failures) > max_test_failures:
+            print(f"_Omitted {len(test_failures) - max_test_failures} additional failed test/package events._")
+            print()
+
+    if panic_like:
+        print("## Panic-Like Output Samples")
+        print()
+        if failed_packages:
+            print("_Only samples from failed packages are shown._")
+            print()
+        for line_no, package, test, output in panic_like:
+            suffix = f" / {test}" if test else ""
+            print(f"### line {line_no}: {package}{suffix}")
+            print("```text")
+            print(output)
+            print("```")
+            print()
+
+    if not build_failures and not test_failures and not panic_like:
+        print("No build-fail, fail, or panic-like output was found in the report.")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Summarize go test -json UT reports.")
+    parser.add_argument("report", type=Path)
+    parser.add_argument("--max-output-lines", type=int, default=80)
+    parser.add_argument("--max-build-failures", type=int, default=10)
+    parser.add_argument("--max-test-failures", type=int, default=10)
+    parser.add_argument("--max-panic-lines", type=int, default=20)
+    args = parser.parse_args()
+
+    summarize(
+        args.report,
+        args.max_output_lines,
+        args.max_build_failures,
+        args.max_test_failures,
+        args.max_panic_lines,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What Changed

- Add `scripts/summarize_ut_report.py` to summarize `go test -json` reports on UT failure.
- Run the UT summary only after UT failure, as a best-effort diagnostic step (`continue-on-error: true`).
- Append the bounded UT failure summary to `GITHUB_STEP_SUMMARY` and save it as `ut-failure-summary.md`.
- Upload `UT-Report.out`, `ut-failure-summary.md`, and `ut-report` with coverage failure artifacts.
- Make coverage cleanup tolerant of no running `mo-service` by using `pgrep ... || true`.
- Avoid masking the original UT/BVT failure when raw coverage or BVT covdata is unavailable after an earlier failed/skipped step.

## Why

Coverage failures can currently end with low-signal cleanup or artifact-generation errors, while the actionable `go test -json` failure is only available after manually downloading and parsing large artifacts. This makes failures like Go vet/build failures hard to diagnose from the CI page.

## Safety

- Successful UT output remains unchanged: the `go test` command still redirects JSON to `UT-Report.out`, and the summary step does not run.
- The existing later `Checkout for Python file` step remains in place for the normal coverage parser path.
- Diagnostic output is bounded by default:
  - max 10 build failures
  - max 10 failed test/package events
  - max 80 output lines per failure
  - max 20 panic-like samples
- The summary script scans the report twice and keeps only bounded tails for failed packages/tests, avoiding whole-report output buffering.

## Validation

- Synthetic build-fail report: summary prints the frontend vet failure clearly.
- Synthetic many-fail report: summary truncates and prints the omitted count.
- `python3 -m py_compile scripts/summarize_ut_report.py`
- YAML parses with PyYAML.
- `actionlint` passed after filtering existing custom-runner/existing-expression warnings:
  - custom runner labels: `arm64-mo-shanghai-4c8g`, `amd64-mo-guangzhou-2xlarge16`
  - existing `needs.setup_mo_test_env` expression warnings
