### PR TITLE
ignore AVX512 files in coverage test

### DIFF
--- a/scripts/.ignore
+++ b/scripts/.ignore
@@ -24,3 +24,6 @@ pkg/common/morpc/examples/*
 *pkg/sql/compile/remoterun.go
 *pkg/sql/compile/remoterunClient.go
 *pkg/sql/compile/remoterunServer.go
+*pkg/vectorindex/metric/distance_func_narrow_amd64.go
+*pkg/vectorindex/metric/distance_func_narrow_f16_amd64.go
+*pkg/vectorindex/metric/distance_func_narrow_int8_amd64.go


### PR DESCRIPTION
files contains the AVX512 code which is not runnable in AVX2 only machine that leads to coverage test failure.  Ignore those files for tests.