### PR TITLE
ci: increase coverage BVT timeout to 60 minutes

### DIFF
--- a/.github/workflows/utils.yaml
+++ b/.github/workflows/utils.yaml
@@ -320,7 +320,7 @@ jobs:
           cd $GITHUB_WORKSPACE/mo-tester
           sed -i "s/socketTimeout:.*/socketTimeout: 300000/g" mo.yml
       - name: Start BVT Test
-        timeout-minutes: 45
+        timeout-minutes: 60
         id: bvt_on_pr_version
         run: |
           export LC_ALL="C.UTF-8"


### PR DESCRIPTION
## What

Increase the `pr_coverage` workflow's `Start BVT Test` step timeout from 45 to 60 minutes.

## Why

The coverage workflow runs both UT and the complete optimistic BVT suite before producing combined coverage. The existing 45-minute BVT budget can expire while the suite is still making progress; 60 minutes gives the suite sufficient headroom while retaining the existing per-SQL 5-minute socket timeout.