### PR TITLE
ci: skip Optimistic compose and standalone BVT on PR

### DIFF
--- a/.github/workflows/e2e-compose.yaml
+++ b/.github/workflows/e2e-compose.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   bvt-docker-compose-push:
-    if: ${{ !github.event.pull_request.draft }}
+    if: false
     environment: ci
     runs-on: ${{ vars.RUNNER_LABEL || 'ubuntu-22.04' }}
     name: multi cn e2e bvt test docker compose(Optimistic/PUSH)

--- a/.github/workflows/e2e-standalone.yaml
+++ b/.github/workflows/e2e-standalone.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   bvt-linux-x86:
-    if: ${{ !github.event.pull_request.draft }}
+    if: false
     environment: ci
     runs-on: ${{ vars.RUNNER_LABEL || 'ubuntu-22.04' }}
     name: e2e BVT Test on Linux/x64(LAUNCH,Optimistic)


### PR DESCRIPTION
## Summary
- Set `if: false` on `bvt-docker-compose-push` (Optimistic/PUSH) in `e2e-compose.yaml`
- Set `if: false` on `bvt-linux-x86` (LAUNCH,Optimistic) in `e2e-standalone.yaml`
- Leaves PESSIMISTIC / PROXY BVT jobs unchanged

## Test plan
- [ ] After merge, open a non-draft PR against `main` / non-`3.0-dev`
- [ ] Confirm Compose Optimistic/PUSH and Standalone LAUNCH Optimistic jobs are skipped
- [ ] Confirm Compose PESSIMISTIC and remaining Standalone BVT jobs still run


Made with [Cursor](https://cursor.com)