### PR TITLE
ci: skip Upgrade Compatibility Target and Release jobs on PR

### DIFF
--- a/.github/workflows/e2e-upgrade.yaml
+++ b/.github/workflows/e2e-upgrade.yaml
@@ -18,6 +18,7 @@ env:
 
 jobs:
   upgrade-ci-target-linux-amd64:
+    if: false
     environment: ci
     runs-on: ${{ vars.RUNNER_LABEL || 'ubuntu-22.04' }}
     name: Compatibility Test With Target on Linux/x64(LAUNCH)
@@ -248,6 +249,7 @@ jobs:
           retention-days: 7
 
   upgrade-ci-release-linux-amd64:
+    if: false
     environment: ci
     runs-on: ${{ vars.RUNNER_LABEL || 'ubuntu-22.04' }}
     name: Compatibility Test With Release on Linux/x64(LAUNCH)


### PR DESCRIPTION
## Summary
- Set `if: false` on `upgrade-ci-target-linux-amd64` (`Compatibility Test With Target on Linux/x64(LAUNCH)`)
- Set `if: false` on `upgrade-ci-release-linux-amd64` (`Compatibility Test With Release on Linux/x64(LAUNCH)`)
- Only touches `e2e-upgrade.yaml`; Compose / Standalone BVT jobs unchanged

## Test plan
- [ ] After merge, open a non-draft PR against `main` / non-`3.0-dev`
- [ ] Confirm both Matrixone Upgrade CI jobs are skipped
- [ ] Confirm other CI groups (Standalone PESSIMISTIC/PROXY, Compose PESSIMISTIC, UT, Utils) still run


Made with [Cursor](https://cursor.com)