### PR TITLE
ci: skip Upgrade Compatibility Target and Release jobs on PR

### DIFF
--- a/.github/workflows/e2e-upgrade.yaml
+++ b/.github/workflows/e2e-upgrade.yaml
@@ -14,6 +14,7 @@ env:
 
 jobs:
   upgrade-ci-target-linux-amd64:
+    if: false
     environment: ci
     runs-on: ubuntu-22.04
     name: Compatibility Test With Target on Linux/x64(LAUNCH)
@@ -218,6 +219,7 @@ jobs:
           retention-days: 7
 
   upgrade-ci-release-linux-amd64:
+    if: false
     environment: ci
     runs-on: ubuntu-22.04
     name: Compatibility Test With Release on Linux/x64(LAUNCH)


### PR DESCRIPTION
## Summary
- Set `if: false` on `upgrade-ci-target-linux-amd64` (`Compatibility Test With Target on Linux/x64(LAUNCH)`)
- Set `if: false` on `upgrade-ci-release-linux-amd64` (`Compatibility Test With Release on Linux/x64(LAUNCH)`)
- Only touches `e2e-upgrade.yaml`; Compose / Standalone BVT jobs unchanged
- Companion change for `release/3.0-dev`

## Test plan
- [ ] After merge, open a non-draft PR against `3.0-dev`
- [ ] Confirm both Matrixone Upgrade CI (3.0) jobs are skipped
- [ ] Confirm other CI groups still run


Made with [Cursor](https://cursor.com)