### PR TITLE
ci: skip Pull Request Basic Benchmark Test on PR

### DIFF
--- a/.github/workflows/utils.yaml
+++ b/.github/workflows/utils.yaml
@@ -423,7 +423,7 @@ jobs:
             }
 
   pr_basic_benchmarks:
-    if: ${{ needs.check_organization_user.outputs.safe_label == '1' || needs.check_organization_user.outputs.in_org == '1' }}
+    if: false
     name: Pull Request Basic Benchmark Test
     needs:
       - check_organization_user


### PR DESCRIPTION
## Summary
- Set `if: false` on `pr_basic_benchmarks` (`Pull Request Basic Benchmark Test`) in `utils.yaml`
- Companion change for `release/3.0-dev`

## Test plan
- [ ] After merge, open a PR targeting `3.0-dev` and confirm Basic Benchmark is skipped


Made with [Cursor](https://cursor.com)