### PR TITLE
fix: pin checkout v6.0.3 for fork PR workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -99,7 +99,7 @@ jobs:
           echo "START_TIME=${time}" >> $GITHUB_OUTPUT
           echo "ACTION_LINK=${action_link}" >> $GITHUB_OUTPUT
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           token: ${{ secrets.TOKEN_ACTION }}
           fetch-depth: "3"
@@ -183,7 +183,7 @@ jobs:
     name: UT Test on Darwin/x86
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           token: ${{ secrets.TOKEN_ACTION }}
           fetch-depth: "3"
@@ -222,7 +222,7 @@ jobs:
     runs-on: ${{ vars.SCA_RUNNER_LABEL || 'arm64-mo-shanghai-8c16g' }}
     name: SCA Test on Linux/arm64
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           token: ${{ secrets.TOKEN_ACTION }}
           fetch-depth: "3"

--- a/.github/workflows/e2e-compose.yaml
+++ b/.github/workflows/e2e-compose.yaml
@@ -26,7 +26,7 @@ jobs:
           echo "========================================="
           sudo df -h /*
       - name: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           token: ${{ secrets.TOKEN_ACTION }}
           fetch-depth: "3"
@@ -197,7 +197,7 @@ jobs:
           echo "========================================="
           sudo df -h /*
       - name: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           token: ${{ secrets.TOKEN_ACTION }}
           fetch-depth: "3"

--- a/.github/workflows/e2e-standalone.yaml
+++ b/.github/workflows/e2e-standalone.yaml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 90
     steps:
       - name: checkout head
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           token: ${{ secrets.TOKEN_ACTION }}
           fetch-depth: "3"
@@ -152,7 +152,7 @@ jobs:
       mo_reuse_enable_checker: true
     steps:
       - name: checkout head
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           token: ${{ secrets.TOKEN_ACTION }}
           path: ./head
@@ -241,7 +241,7 @@ jobs:
       mo_reuse_enable_checker: true
     steps:
       - name: checkout head
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           token: ${{ secrets.TOKEN_ACTION }}
           fetch-depth: "3"

--- a/.github/workflows/e2e-upgrade.yaml
+++ b/.github/workflows/e2e-upgrade.yaml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: checkout head
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           token: ${{ secrets.TOKEN_ACTION }}
           path: ./head
@@ -259,7 +259,7 @@ jobs:
 
     steps:
       - name: Checkout Head
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           token: ${{ secrets.TOKEN_ACTION }}
           path: ./head

--- a/.github/workflows/utils.yaml
+++ b/.github/workflows/utils.yaml
@@ -96,7 +96,7 @@ jobs:
     # if you change runner, must modify L117
     runs-on: amd64-mo-guangzhou-2xlarge16
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           token: ${{ secrets.TOKEN_ACTION }}
           fetch-depth: "1"
@@ -477,7 +477,7 @@ jobs:
     environment: ci
     runs-on: amd64-mo-guangzhou-2xlarge16
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           token: ${{ secrets.TOKEN_ACTION }}
           path: ./matrixone


### PR DESCRIPTION
## Summary

Temporarily pin the `actions/checkout` steps that fetch a pull request's head repository to the last known working v6.0.3 commit:

```text
df4cb1c069e1874edd31b4311f1884172cec0e10
```

Only checkout steps using `github.event.pull_request.head.repo.full_name` are pinned. Checkouts of trusted fixed repositories such as `matrixorigin/mo-tester` and `matrixorigin/CI` remain on `@v6`.

## Background

`actions/checkout@v6` was a floating major-version reference. On 2026-07-20, GitHub published v6.1.0 and moved the `v6` tag from `df4cb1c` to `d23441a`.

v6.1.0 introduced a breaking security default that rejects checking out fork PR code from a `pull_request_target` workflow unless `allow-unsafe-pr-checkout` is explicitly enabled. MatrixOne's PR entrypoint uses `pull_request_target`, inherits secrets, and delegates to these reusable workflows, which explicitly check out the fork repository and branch.

As a result, all fork PR jobs now fail during checkout before any MatrixOne code is built or tested. Example: matrixorigin/matrixone#25909, Actions run https://github.com/matrixorigin/matrixone/actions/runs/29756799570.

A successful job immediately before the release resolved `actions/checkout@v6` to `df4cb1c`; a failing job 34 minutes later resolved the same reference to `d23441a`, with the same runner image and CI workflow revision.

## Scope

Pin 12 PR-head checkout steps across:

- `.github/workflows/ci.yaml`
- `.github/workflows/e2e-upgrade.yaml`
- `.github/workflows/e2e-compose.yaml`
- `.github/workflows/e2e-standalone.yaml`
- `.github/workflows/utils.yaml`

This covers UT, SCA, upgrade, Compose/Standalone BVT, coverage, and benchmark workflows for fork PRs targeting MatrixOne `main`.

## Security note and follow-up

This is an explicit temporary rollback to the pre-v6.1.0 behavior. It restores fork PR CI but also preserves the existing risk of executing fork-controlled code in a `pull_request_target` context with inherited secrets and privileged runners.

The durable fix is to split the model:

- run untrusted PR code under `pull_request` with read-only permissions, no inherited secrets, and isolated runners;
- keep `pull_request_target` for metadata/label/authorization work only, without checking out PR code;
- gate genuinely privileged tests by exact head SHA and run them with short-lived, least-privilege credentials in an isolated environment.

Do not replace this pin with `allow-unsafe-pr-checkout: true` as the long-term solution.

## Validation

- Confirmed the pinned SHA is the v6.0.3 release commit.
- Confirmed every checkout step that uses `github.event.pull_request.head.repo.full_name` is pinned.
- Confirmed fixed-repository checkout steps remain unchanged on `@v6`.
- `git diff --check`
- `actionlint` passed for the changed workflows after ignoring existing custom-runner-label and pre-existing expression-schema findings.
