### PR TITLE
ci: ignore SIMD amd64 metric kernels in coverage

### DIFF
--- a/scripts/.ignore
+++ b/scripts/.ignore
@@ -24,6 +24,9 @@ pkg/common/morpc/examples/*
 *pkg/sql/compile/remoterun.go
 *pkg/sql/compile/remoterunClient.go
 *pkg/sql/compile/remoterunServer.go
+*pkg/vectorindex/metric/distance_func_amd64.go
 *pkg/vectorindex/metric/distance_func_narrow_amd64.go
+*pkg/vectorindex/metric/distance_func_narrow_avx2_amd64.go
 *pkg/vectorindex/metric/distance_func_narrow_f16_amd64.go
 *pkg/vectorindex/metric/distance_func_narrow_int8_amd64.go
+*pkg/vectorindex/metric/distance_func_narrow_uint8_amd64.go


### PR DESCRIPTION
The metric distance_func amd64 SIMD files are built only under GOEXPERIMENT=simd (the BVT mo-service binary), while the UT `go test` runs with simd off, so their unit tests never execute and the files show 0.0% in merged coverage. On the AVX512-less Zen 2 runner the AVX512 kernels cannot run at all. Add the 3 remaining files to the coverage ignore list so they no longer fail the PR coverage gate, matching the already-ignored narrow/f16/int8 siblings.