### PR TITLE
ci: build multi-arch images on native runners

### DIFF
--- a/.github/workflows/image-build.yaml
+++ b/.github/workflows/image-build.yaml
@@ -44,8 +44,19 @@ permissions:
 
 jobs:
   dockerhub:
+    name: Build ${{ matrix.platform }}
     environment: ci
-    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            arch: amd64
+            runner: ubuntu-22.04
+          - platform: linux/arm64
+            arch: arm64
+            runner: ubuntu-22.04-arm
+    runs-on: ${{ matrix.runner }}
 
     steps:
       - name: Checkout
@@ -72,38 +83,23 @@ jobs:
         run: |
           DOCKER_IMAGE=${{ secrets.DOCKERHUB_USERNAME }}/${GITHUB_REPOSITORY#*/}
           ACR_DOCKER_IMAGE="registry.cn-shanghai.aliyuncs.com/${DOCKER_IMAGE}"
-          # ECR_DOCKER_IMAGE="${{ steps.login-ecr-public.outputs.registry }}/${{ inputs.alias }}/${{ inputs.repo }}"
-          
           VERSION=nightly-${GITHUB_SHA::8}
-          # If this is git tag, use the tag name as a docker tag
           if [[ $GITHUB_REF == refs/tags/* ]]; then
             VERSION=${GITHUB_REF#refs/tags/v}
           fi
-          
-          # TAGS="${DOCKER_IMAGE}:${VERSION},${ACR_DOCKER_IMAGE}:${VERSION},${ECR_DOCKER_IMAGE}:${VERSION}"
-          TAGS="${DOCKER_IMAGE}:${VERSION},${ACR_DOCKER_IMAGE}:${VERSION}"
-          # If the VERSION looks like a version number, assume that
-          # this is the most recent version of the image and also
-          # tag it 'latest'.
-          if [[ $VERSION =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
-            # TAGS="$TAGS,${DOCKER_IMAGE}:latest,${ACR_DOCKER_IMAGE}:latest,${ECR_DOCKER_IMAGE}:latest"
-            TAGS="$TAGS,${DOCKER_IMAGE}:latest,${ACR_DOCKER_IMAGE}:latest"
-          fi
-          
-          # Set output parameters.
-          echo "tags=${TAGS}" >> $GITHUB_OUTPUT
-          echo "docker_image=${DOCKER_IMAGE}" >> $GITHUB_OUTPUT
-          echo "cache_repo=${{ secrets.DOCKERHUB_USERNAME }}/${GITHUB_REPOSITORY#*/}:cache" >> $GITHUB_OUTPUT
+          {
+            echo "docker_image=${DOCKER_IMAGE}"
+            echo "acr_docker_image=${ACR_DOCKER_IMAGE}"
+            echo "version=${VERSION}"
+            echo "cache_repo=${DOCKER_IMAGE}:cache-${{ matrix.arch }}"
+            echo "legacy_cache_repo=${DOCKER_IMAGE}:cache"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Get image info
         run: |
-          echo "image-tags: ${{ steps.prep.outputs.tags }}"
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-        with:
-          image: tonistiigi/binfmt:latest
-          platforms:  linux/amd64,linux/arm64
+          echo "platform: ${{ matrix.platform }}"
+          echo "docker-image: ${{ steps.prep.outputs.docker_image }}:${{ steps.prep.outputs.version }}-${{ matrix.arch }}"
+          echo "acr-image: ${{ steps.prep.outputs.acr_docker_image }}:${{ steps.prep.outputs.version }}-${{ matrix.arch }}"
 
       - name: Set up Docker Buildx
         id: buildx
@@ -128,8 +124,73 @@ jobs:
           builder: ${{ steps.buildx.outputs.name }}
           context: .
           file: ./optools/images/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platform }}
           push: true
-          tags: ${{ steps.prep.outputs.tags }}
-          cache-from: type=registry,ref=${{ steps.prep.outputs.cache_repo }}
+          tags: |
+            ${{ steps.prep.outputs.docker_image }}:${{ steps.prep.outputs.version }}-${{ matrix.arch }}
+            ${{ steps.prep.outputs.acr_docker_image }}:${{ steps.prep.outputs.version }}-${{ matrix.arch }}
+          cache-from: |
+            type=registry,ref=${{ steps.prep.outputs.cache_repo }}
+            type=registry,ref=${{ steps.prep.outputs.legacy_cache_repo }}
           cache-to: type=registry,ref=${{ steps.prep.outputs.cache_repo }},mode=max
+
+  manifest:
+    name: Publish multi-arch manifests
+    environment: ci
+    runs-on: ubuntu-22.04
+    needs: dockerhub
+
+    steps:
+      - name: Prepare
+        id: prep
+        run: |
+          DOCKER_IMAGE=${{ secrets.DOCKERHUB_USERNAME }}/${GITHUB_REPOSITORY#*/}
+          ACR_DOCKER_IMAGE="registry.cn-shanghai.aliyuncs.com/${DOCKER_IMAGE}"
+          VERSION=nightly-${GITHUB_SHA::8}
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/v}
+          fi
+          {
+            echo "docker_image=${DOCKER_IMAGE}"
+            echo "acr_docker_image=${ACR_DOCKER_IMAGE}"
+            echo "version=${VERSION}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to Alicloud Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: registry.cn-shanghai.aliyuncs.com
+          username: ${{ secrets.ACR_USERNAME }}
+          password: ${{ secrets.ACR_TOKEN }}
+
+      - name: Create manifests
+        env:
+          DOCKER_IMAGE: ${{ steps.prep.outputs.docker_image }}
+          ACR_DOCKER_IMAGE: ${{ steps.prep.outputs.acr_docker_image }}
+          VERSION: ${{ steps.prep.outputs.version }}
+        run: |
+          tag_args=(--tag "${DOCKER_IMAGE}:${VERSION}")
+          acr_tag_args=(--tag "${ACR_DOCKER_IMAGE}:${VERSION}")
+          if [[ $VERSION =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+            tag_args+=(--tag "${DOCKER_IMAGE}:latest")
+            acr_tag_args+=(--tag "${ACR_DOCKER_IMAGE}:latest")
+          fi
+
+          docker buildx imagetools create "${tag_args[@]}" \
+            "${DOCKER_IMAGE}:${VERSION}-amd64" \
+            "${DOCKER_IMAGE}:${VERSION}-arm64"
+          docker buildx imagetools create "${acr_tag_args[@]}" \
+            "${ACR_DOCKER_IMAGE}:${VERSION}-amd64" \
+            "${ACR_DOCKER_IMAGE}:${VERSION}-arm64"
+
+          docker buildx imagetools inspect "${DOCKER_IMAGE}:${VERSION}"
+          docker buildx imagetools inspect "${ACR_DOCKER_IMAGE}:${VERSION}"


### PR DESCRIPTION
## Summary

- Build linux/amd64 on ubuntu-22.04 and linux/arm64 on ubuntu-22.04-arm.
- Remove QEMU from the MatrixOne image build path.
- Push per-platform staging images to DockerHub and ACR, then publish the existing nightly/release multi-arch tags only after both builds succeed.
- Keep the existing optools/images/Dockerfile; this PR does not introduce the new native/Go cache design.
- Split the existing registry cache tag by architecture to avoid concurrent writers, with the current shared cache retained as the migration fallback.

## Why

MatrixOne run 29962616189 spent about 45m55s in the emulated arm64 build versus 5m13s for native amd64. Native thirdparty/CGO work was about 8m42s and the ARM Go build about 37m13s. GitHub now provides a standard native ubuntu-22.04-arm runner, so QEMU is no longer necessary.

## Validation

- actionlint v1.7.12 passed.
- git diff --check passed.
- Independent high-level review found no merge blocker.
- Failure closure checked: if either platform fails, the manifest job is skipped and neither the canonical version tag nor latest is published.