### PR TITLE
ci: increase BVT timeouts to 75 minutes

### DIFF
--- a/.github/workflows/e2e-compose.yaml
+++ b/.github/workflows/e2e-compose.yaml
@@ -13,7 +13,7 @@ jobs:
     environment: ci
     runs-on: ${{ vars.RUNNER_LABEL || 'ubuntu-22.04' }}
     name: multi cn e2e bvt test docker compose(Optimistic/PUSH)
-    timeout-minutes: 60
+    timeout-minutes: 75
 
     steps:
       - name: Pre Clean Some Unneeded Images
@@ -185,7 +185,7 @@ jobs:
     environment: ci
     runs-on: ${{ vars.RUNNER_LABEL || 'ubuntu-22.04' }}
     name: multi cn e2e bvt test docker compose(PESSIMISTIC)
-    timeout-minutes: 60
+    timeout-minutes: 75
     steps:
       - name: Pre Clean Some Unneeded Images
         run: |

--- a/.github/workflows/e2e-standalone.yaml
+++ b/.github/workflows/e2e-standalone.yaml
@@ -147,7 +147,7 @@ jobs:
   multi-cn-proxy-bvt-linux-x86:
     runs-on: ${{ vars.RUNNER_LABEL || 'ubuntu-22.04' }}
     name: Multi-CN e2e BVT Test on Linux/x64(LAUNCH, PROXY)
-    timeout-minutes: 60
+    timeout-minutes: 75
     env:
       mo_reuse_enable_checker: true
     steps:
@@ -236,7 +236,7 @@ jobs:
   pessimistic-bvt-linux-x86:
     runs-on: ${{ vars.RUNNER_LABEL || 'ubuntu-22.04' }}
     name: e2e BVT Test on Linux/x64(LAUNCH, PESSIMISTIC)
-    timeout-minutes: 60
+    timeout-minutes: 75
     env:
       mo_reuse_enable_checker: true
     steps:

--- a/.github/workflows/merge-trigger-tke.yaml
+++ b/.github/workflows/merge-trigger-tke.yaml
@@ -307,7 +307,7 @@ jobs:
           echo "$JAVA_HOME/bin" >> $GITHUB_PATH
       - name: Generate MO-Tester Config and Start BVT Test
         if: ${{ always() && !cancelled() }}
-        timeout-minutes: 60
+        timeout-minutes: 75
         run: |
           export LC_ALL="C.UTF-8"
           locale

--- a/.github/workflows/utils.yaml
+++ b/.github/workflows/utils.yaml
@@ -320,7 +320,7 @@ jobs:
           cd $GITHUB_WORKSPACE/mo-tester
           sed -i "s/socketTimeout:.*/socketTimeout: 300000/g" mo.yml
       - name: Start BVT Test
-        timeout-minutes: 60
+        timeout-minutes: 75
         id: bvt_on_pr_version
         run: |
           export LC_ALL="C.UTF-8"


### PR DESCRIPTION
## Summary

- increase compose BVT job timeouts from 60 to 75 minutes
- increase standalone multi-CN/proxy and pessimistic BVT job timeouts from 60 to 75 minutes
- increase TKE and coverage BVT step timeouts from 60 to 75 minutes
- keep shorter setup/launch and workload-specific timeout guards unchanged

## Why

Recent hosted-runner slowdowns have stretched otherwise progressing BVT jobs beyond the 60-minute limit. A 75-minute ceiling provides headroom for transient runner variance while preserving bounded execution.

### Same-SHA rerun evidence

The same MatrixOne commit (`eb35456fdf05c64d9140a4cca72fdd15f47bd894`) produced both outcomes in [run 30005896526](https://github.com/matrixorigin/matrixone/actions/runs/30005896526):

- attempt 1 was cancelled by the 60-minute job limit while BVT was still progressing; BVT had run for 55 minutes and completed 914 cases
- attempt 2 passed unchanged in 44m59s total, with BVT completing in 38m15s
- the rerun completed all scripts successfully, confirming that the first timeout was transient runner variance rather than a deterministic test hang

A scan of 194 recent instances of the same compose job also found 123 successful runs with a 43.9-minute median and 46.5-minute P90. Rare slow runners stretched otherwise progressing test cases by roughly 1.6x, which can exceed the current 60-minute ceiling. Raising the limit to 75 minutes covers this observed tail without making execution unbounded.

## Validation

- `git diff --check`
- verified no `timeout-minutes: 60` entries remain in `.github`