### PR TITLE
ci: temporarily skip HDFS setup in Linux UT

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -110,9 +110,6 @@ jobs:
         with:
           setup-java: true
           go-version-file: "${{ github.workspace }}/go.mod"
-      - uses: matrixorigin/setup-hdfs@master
-        with:
-          hdfs-download-url: "https://github.com/matrixorigin/CI/releases/download/hadoop-binary-3.4.1/hadoop-3.4.1.tar.gz"
       - name: Set env
         run: |
           echo "endpoint=${{ secrets.S3ENDPOINT }}" >> $GITHUB_ENV


### PR DESCRIPTION
## What changed

Remove `matrixorigin/setup-hdfs` from the Linux/x86 UT job. The action assumes a localhost SSH daemon, which is unavailable on the IDC self-hosted runner and currently prevents the unit tests from starting.

`pkg/fileservice.TestHDFS` already probes the NameNode and skips when it is unavailable, so the remaining UT suite can run. The Darwin HDFS setup is unchanged.

## Follow-up

Adapt `matrixorigin/setup-hdfs` to start the single-node HDFS daemons without SSH, then restore this step.

## Validation

- `git diff --check`
- Confirmed only the Linux/x86 setup step is removed; Darwin remains unchanged.