### PR TITLE
fix: support grouped BVT on legacy branches

### DIFF
--- a/.github/workflows/e2e-compose-parallel.yaml
+++ b/.github/workflows/e2e-compose-parallel.yaml
@@ -334,7 +334,14 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
           cd "$GITHUB_WORKSPACE"
           set -o pipefail
-          bash ./optools/run_bvt_group.sh \
+          bvt_runner="$GITHUB_WORKSPACE/optools/run_bvt_group.sh"
+          if [ ! -f "${bvt_runner}" ]; then
+            bvt_runner="${RUNNER_TEMP}/run_bvt_group.sh"
+            curl --fail --silent --show-error --location \
+              "https://raw.githubusercontent.com/matrixorigin/matrixone/7cb78aa5f88e3b98163f6b3bffb5f71586c0cbbf/optools/run_bvt_group.sh" \
+              --output "${bvt_runner}"
+          fi
+          bash "${bvt_runner}" \
             "$GITHUB_WORKSPACE/mo-tester" \
             "$GITHUB_WORKSPACE/test/distributed/cases" \
             "${bvt_group}" 2>&1 | tee "${RUNNER_TEMP}/bvt-compose.log"

--- a/.github/workflows/e2e-standalone-parallel.yaml
+++ b/.github/workflows/e2e-standalone-parallel.yaml
@@ -346,7 +346,14 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
           cd "$GITHUB_WORKSPACE/head"
           set -o pipefail
-          bash ./optools/run_bvt_group.sh \
+          bvt_runner="$GITHUB_WORKSPACE/head/optools/run_bvt_group.sh"
+          if [ ! -f "${bvt_runner}" ]; then
+            bvt_runner="${RUNNER_TEMP}/run_bvt_group.sh"
+            curl --fail --silent --show-error --location \
+              "https://raw.githubusercontent.com/matrixorigin/matrixone/7cb78aa5f88e3b98163f6b3bffb5f71586c0cbbf/optools/run_bvt_group.sh" \
+              --output "${bvt_runner}"
+          fi
+          bash "${bvt_runner}" \
             "$GITHUB_WORKSPACE/mo-tester" \
             "$GITHUB_WORKSPACE/head/test/distributed/cases" \
             "${bvt_group}" \


### PR DESCRIPTION
## What this PR does

The parallel BVT workflows introduced with matrixorigin/matrixone#26179 execute `optools/run_bvt_group.sh` from the pull request checkout. Release branches such as `4.2-dev` predate that helper, so their BVT jobs start MatrixOne successfully but fail before running any SQL with exit code 127:

```text
bash: ./optools/run_bvt_group.sh: No such file or directory
```

This change keeps the checked-out helper as the primary path and adds a compatibility fallback in both parallel BVT workflows. If the PR checkout does not contain the helper, the job downloads the script from the immutable MatrixOne commit that introduced it (`7cb78aa5f88e3b98163f6b3bffb5f71586c0cbbf`) and runs the same grouped-BVT flow.

Affected workflows:

- Compose + Proxy grouped BVT
- Launch + Pessimistic grouped BVT

This preserves complementary group assignment and coverage behavior for `main` while allowing older release branches to use the new CI workflows without backporting CI-only helper files.

## Reproduction

- MatrixOne PR: matrixorigin/matrixone#26228 (`4.2-dev`)
- Failed run: https://github.com/matrixorigin/matrixone/actions/runs/30245505107
- Failed jobs both report the missing `run_bvt_group.sh` path.

## Validation

- `actionlint` v1.7.7 passes for both modified workflows.
- Both YAML files parse successfully.
- `git diff --check` passes.
- The fallback URL downloads successfully, passes `bash -n`, and its SHA-256 matches `optools/run_bvt_group.sh` at the pinned MatrixOne commit.