### PR TITLE
fix: tolerate missing Compose coverage on legacy branches

### DIFF
--- a/.github/workflows/coverage-merge.yaml
+++ b/.github/workflows/coverage-merge.yaml
@@ -107,8 +107,22 @@ jobs:
 
           mapfile -t ut_profiles < <(find "${artifact_dir}" -type f -name 'ut-coverage.out' | sort)
           mapfile -t bvt_profiles < <(find "${artifact_dir}" -type f -name 'bvt-*.out' | sort)
-          if [ "${#ut_profiles[@]}" -ne 1 ] || [ "${#bvt_profiles[@]}" -ne 2 ]; then
-            echo '::error::expected one UT profile and two BVT profiles'
+          if [ "${#ut_profiles[@]}" -ne 1 ]; then
+            echo '::error::expected exactly one UT profile'
+            find "${artifact_dir}" -type f -print || true
+            exit 1
+          fi
+          if [ '${{ github.base_ref }}' = 'main' ]; then
+            if [ "${#bvt_profiles[@]}" -ne 2 ]; then
+              echo '::error::expected two BVT profiles on main'
+              find "${artifact_dir}" -type f -print || true
+              exit 1
+            fi
+          elif [ "${#bvt_profiles[@]}" -eq 1 ] \
+            && [ "$(basename "${bvt_profiles[0]}")" = 'bvt-standalone.out' ]; then
+            echo '::warning::merging coverage without the unsupported legacy Compose profile'
+          elif [ "${#bvt_profiles[@]}" -ne 2 ]; then
+            echo '::error::expected two BVT profiles, or the standalone profile alone on a legacy branch'
             find "${artifact_dir}" -type f -print || true
             exit 1
           fi

--- a/.github/workflows/e2e-compose-parallel.yaml
+++ b/.github/workflows/e2e-compose-parallel.yaml
@@ -430,6 +430,12 @@ jobs:
           set -uo pipefail
           coverage_dir="$GITHUB_WORKSPACE/coverage"
           coverage_profile="$RUNNER_TEMP/bvt-compose.out"
+          compose_file="$GITHUB_WORKSPACE/etc/launch-tae-compose/compose.yaml"
+          if ! grep -Eq 'GOCOVERDIR=/coverage' "${compose_file}" \
+            || ! grep -Eq 'coverage:/coverage' "${compose_file}"; then
+            echo '::warning::Compose BVT coverage is unsupported by this legacy branch; keeping the successful BVT result'
+            exit 0
+          fi
           if go tool covdata textfmt -i="${coverage_dir}" -o "${coverage_profile}"; then
             test -s "${coverage_profile}"
           elif [ "${{ steps.bvt_on_pr_version.conclusion }}" = "success" ]; then


### PR DESCRIPTION
## What this PR does / why we need it

Legacy MatrixOne branches such as `4.2-dev` do not mount `/coverage` or set `GOCOVERDIR` in their Compose configuration. Their Compose BVT can therefore pass while the reusable workflow fails afterward when it requires a coverage profile.

This change:
- keeps the successful Compose BVT result when the checked-out legacy Compose configuration has no coverage wiring;
- still requires both BVT coverage profiles on `main`;
- lets legacy branches merge UT plus standalone BVT coverage when only Compose coverage is unsupported;
- retains both BVT manifests, so complementary group and generation validation is unchanged.

Observed in MatrixOne run: https://github.com/matrixorigin/matrixone/actions/runs/30250338336

## Testing

- `git diff --check`
- exercised main/legacy profile-count branches and Compose capability detection with shell fixtures
- verified `main` still rejects a missing Compose profile
