### PR TITLE
fix: recognize pessimistic coverage profile

### DIFF
--- a/.github/workflows/coverage-merge.yaml
+++ b/.github/workflows/coverage-merge.yaml
@@ -119,7 +119,7 @@ jobs:
               exit 1
             fi
           elif [ "${#bvt_profiles[@]}" -eq 1 ] \
-            && [ "$(basename "${bvt_profiles[0]}")" = 'bvt-standalone.out' ]; then
+            && [ "$(basename "${bvt_profiles[0]}")" = 'bvt-pessimistic.out' ]; then
             echo '::warning::merging coverage without the unsupported legacy Compose profile'
           elif [ "${#bvt_profiles[@]}" -ne 2 ]; then
             echo '::error::expected two BVT profiles, or the standalone profile alone on a legacy branch'


### PR DESCRIPTION
## What this PR does / why we need it

CI #406 allowed legacy branches to merge coverage without unsupported Compose coverage, but checked for `bvt-standalone.out`. The standalone reusable workflow actually publishes `bvt-pessimistic.out`, so the coverage merge still rejected the valid legacy artifact set after every producer passed.

Use the producer's actual profile filename.

Failure evidence: https://github.com/matrixorigin/matrixone/actions/runs/30253865089

## Testing

- `git diff --check`
- exercised zero, one, and two BVT profile scenarios for `main` and `4.2-dev`
- verified `main` still rejects a single profile
- verified `4.2-dev` accepts only the single `bvt-pessimistic.out` legacy fallback
