### PR TITLE
fix: provide admin credentials for TPCC synccommit

### DIFF
--- a/.github/workflows/merge-trigger-tke.yaml
+++ b/.github/workflows/merge-trigger-tke.yaml
@@ -732,6 +732,9 @@ jobs:
         if: ${{ always() && !cancelled() }}
         timeout-minutes: 20
         id: load_tpcc_data
+        env:
+          SYNC_USER: dump
+          SYNC_PASS: "111"
         run: |
           set -uo pipefail
           export LC_ALL="C.UTF-8"


### PR DESCRIPTION
## Summary

- pass the existing `dump/111` test credentials to `mo-load-data` through `SYNC_USER` and `SYNC_PASS`
- keep `tpcc_test:admin` as the account used for TPCC DDL and data loading

## Why

`mo_ctl(synccommit)` requires `sys:moadmin`. The TPCC loader currently reuses `tpcc_test:admin`, so the barrier is rejected and a following `LOAD DATA` can race catalog visibility across CNs.

Companion loader change: matrixorigin/mo-load-data#18.
Related issue: matrixorigin/matrixone#26313.

## Validation

- parsed `.github/workflows/merge-trigger-tke.yaml` as YAML
- verified the `load_tpcc_data` step receives string values `SYNC_USER=dump` and `SYNC_PASS=111`
- `git diff --check`

## Merge order

Merge this PR before matrixorigin/mo-load-data#18. The current loader ignores these environment variables, so this change is backward compatible and prevents a CI failure window when the loader begins failing fast.