### PR TITLE
fix: fail fast on coverage CGO preparation

### DIFF
--- a/.github/workflows/coverage-ut.yaml
+++ b/.github/workflows/coverage-ut.yaml
@@ -149,10 +149,21 @@ jobs:
         with:
           setup-java: true
           go-version-file: "${{ github.workspace }}/go.mod"
+      - name: Checkout CI coverage helper
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          token: ${{ secrets.TOKEN_ACTION }}
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
+          sparse-checkout: scripts/prepare_coverage_cgo.sh
+          sparse-checkout-cone-mode: false
+          path: .ci-workflow
       - id: coverage_ut
         name: Run coverage unit tests
         timeout-minutes: 45
         continue-on-error: true
+        env:
+          GOPROXY: http://goproxy.goproxy.svc.cluster.local,https://goproxy.cn,https://proxy.golang.org
         run: |
           set -euo pipefail
           cd "$GITHUB_WORKSPACE"
@@ -163,17 +174,18 @@ jobs:
           export bucket='${{ secrets.S3BUCKET }}'
           export TEST_S3FS_ALIYUN='${{ secrets.TEST_S3FS_ALIYUN }}'
           export TEST_S3FS_QCLOUD='${{ secrets.TEST_S3FS_QCLOUD }}'
+          coverage_profile="${RUNNER_TEMP}/ut-coverage.out"
+          coverage_report="${RUNNER_TEMP}/ut-coverage-report.json"
+          rm -f "${coverage_profile}" "${coverage_report}"
 
           test_scope=$(go list -mod=readonly ./... | grep -v 'driver\|engine/aoe\|engine/memEngine\|pkg/catalog')
           cover_pkgs=$(printf '%s\n' "${test_scope}" | paste -sd, -)
           test -n "${cover_pkgs}"
 
-          make clean && make config && make cgo && make thirdparties
+          "$GITHUB_WORKSPACE/.ci-workflow/scripts/prepare_coverage_cgo.sh"
           thirdparties_install_dir="$GITHUB_WORKSPACE/thirdparties/install"
           cgo_cflags="-I${GITHUB_WORKSPACE}/cgo -I${thirdparties_install_dir}/include"
           cgo_ldflags="-L${GITHUB_WORKSPACE}/cgo -lmo -L${thirdparties_install_dir}/lib -lusearch_c -Wl,-rpath,${thirdparties_install_dir}/lib -lm"
-          coverage_profile="${RUNNER_TEMP}/ut-coverage.out"
-          coverage_report="${RUNNER_TEMP}/ut-coverage-report.json"
 
           # Keep the same all-package coverage scope and external storage
           # coverage as main. Save the verbose JSON report as an artifact

--- a/scripts/prepare_coverage_cgo.sh
+++ b/scripts/prepare_coverage_cgo.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+make clean
+make config
+make cgo
+
+for header in \
+    thirdparties/install/include/xxhash.h \
+    thirdparties/install/include/roaring.h \
+    thirdparties/install/include/usearch.h; do
+    if [[ ! -f "${header}" ]]; then
+        echo "missing required CGO header: ${header}" >&2
+        exit 1
+    fi
+done

--- a/scripts/test_prepare_coverage_cgo.py
+++ b/scripts/test_prepare_coverage_cgo.py
@@ -1,0 +1,107 @@
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT = Path(__file__).with_name("prepare_coverage_cgo.sh")
+
+
+def _fake_make(tmp_path: Path) -> tuple[Path, Path]:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    log_path = tmp_path / "make.log"
+    make_path = bin_dir / "make"
+    make_path.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+target="${1:-}"
+printf '%s\\n' "${target}" >> "${MAKE_LOG}"
+if [[ "${target}" == "${FAIL_TARGET:-}" ]]; then
+  exit "${FAIL_CODE:-1}"
+fi
+if [[ "${target}" == "cgo" && "${CREATE_HEADERS:-0}" == "1" ]]; then
+  mkdir -p thirdparties/install/include
+  for header in xxhash.h roaring.h usearch.h; do
+    if [[ "${header}" != "${OMIT_HEADER:-}" ]]; then
+      touch "thirdparties/install/include/${header}"
+    fi
+  done
+fi
+"""
+    )
+    make_path.chmod(0o755)
+    return bin_dir, log_path
+
+
+def _run_helper(
+    tmp_path: Path,
+    bin_dir: Path,
+    log_path: Path,
+    **extra_env: str,
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{bin_dir}{os.pathsep}{env['PATH']}",
+            "MAKE_LOG": str(log_path),
+        }
+    )
+    env.update(extra_env)
+    return subprocess.run(
+        ["bash", str(SCRIPT)],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_config_failure_stops_before_cgo(tmp_path):
+    """A failed package-graph check must not start native compilation."""
+    bin_dir, log_path = _fake_make(tmp_path)
+
+    result = _run_helper(
+        tmp_path,
+        bin_dir,
+        log_path,
+        FAIL_TARGET="config",
+        FAIL_CODE="23",
+    )
+
+    assert result.returncode == 23
+    assert log_path.read_text().splitlines() == ["clean", "config"]
+
+
+@pytest.mark.parametrize("missing_header", ["xxhash.h", "roaring.h", "usearch.h"])
+def test_missing_required_headers_fails_preparation(tmp_path, missing_header):
+    """A nominal make result must not admit an incomplete native install."""
+    bin_dir, log_path = _fake_make(tmp_path)
+
+    result = _run_helper(
+        tmp_path,
+        bin_dir,
+        log_path,
+        CREATE_HEADERS="1",
+        OMIT_HEADER=missing_header,
+    )
+
+    assert result.returncode != 0
+    assert f"thirdparties/install/include/{missing_header}" in result.stderr
+
+
+def test_successful_preparation_builds_in_order(tmp_path):
+    """A complete native build must admit the coverage test phase."""
+    bin_dir, log_path = _fake_make(tmp_path)
+
+    result = _run_helper(
+        tmp_path,
+        bin_dir,
+        log_path,
+        CREATE_HEADERS="1",
+    )
+
+    assert result.returncode == 0
+    assert log_path.read_text().splitlines() == ["clean", "config", "cgo"]


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue matrixorigin/matrixone#26452

## What this PR does / why we need it:

The coverage workflow ran native preparation as one `&&` list:

```bash
make clean && make config && make cgo && make thirdparties
```

When `make config` exhausted its retries after the external Go proxy timed
out, Bash did not honor `errexit` for that non-final command in the `&&`
list. Native compilation was skipped, but the step continued into
`go test` after `make clean` had removed the installed headers. That
produced the misleading `xxhash.h`, `roaring.h`, and `usearch.h` failure
cascade reported in the issue.

This PR:

- moves coverage native preparation into a tested fail-fast helper whose
  commands execute independently;
- verifies all three required CGO headers before admitting `go test`;
- checks out the helper from the exact reusable-workflow commit, so callers
  cannot observe a helper/workflow version mismatch;
- restores the CI-local Go proxy configuration for dependency resolution;
- removes stale coverage outputs before preparation, preventing a reused
  runner from publishing diagnostics from an earlier run.

The change is limited to CI orchestration. It does not alter MatrixOne
runtime code, SQL semantics, or CGO build contents.

Tested with:

`/private/tmp/mo-ci-26452-venv/bin/python -m pytest -q scripts`

`bash -n scripts/prepare_coverage_cgo.sh`

`go run github.com/rhysd/actionlint/cmd/actionlint@latest -ignore 'label "amd64-mo-guangzhou-2xlarge16" is unknown' -ignore 'property "workflow_(repository|sha)" is not defined' .github/workflows/coverage-ut.yaml`

`git diff --check`
