### PR TITLE
ci: separate object storage integration from coverage UT

### DIFF
--- a/.github/workflows/coverage-ut.yaml
+++ b/.github/workflows/coverage-ut.yaml
@@ -16,27 +16,6 @@ on:
       TOKEN_ACTION:
         description: "Token for checkout (e.g. pull from fork/private)"
         required: false
-      TEST_S3FS_ALIYUN:
-        description: "Object storage configuration for UT coverage"
-        required: false
-      TEST_S3FS_QCLOUD:
-        description: "Object storage configuration for UT coverage"
-        required: false
-      S3ENDPOINT:
-        description: "S3ENDPOINT For Test"
-        required: false
-      S3REGION:
-        description: "S3REGION For Test"
-        required: false
-      S3APIKEY:
-        description: "S3APIKEY For Test"
-        required: false
-      S3APISECRET:
-        description: "S3APISECRET For Test"
-        required: false
-      S3BUCKET:
-        description: "S3BUCKET For Test"
-        required: false
 
 jobs:
   check_coverage_eligibility:
@@ -86,39 +65,14 @@ jobs:
           else
             echo 'safe_label=0' >> "$GITHUB_OUTPUT"
           fi
-      - id: check_coverage_secrets
-        name: Check coverage secrets
-        env:
-          TEST_S3FS_ALIYUN: ${{ secrets.TEST_S3FS_ALIYUN }}
-          TEST_S3FS_QCLOUD: ${{ secrets.TEST_S3FS_QCLOUD }}
-          S3ENDPOINT: ${{ secrets.S3ENDPOINT }}
-          S3REGION: ${{ secrets.S3REGION }}
-          S3APIKEY: ${{ secrets.S3APIKEY }}
-          S3APISECRET: ${{ secrets.S3APISECRET }}
-          S3BUCKET: ${{ secrets.S3BUCKET }}
-        run: |
-          set -euo pipefail
-          missing=()
-          for name in TEST_S3FS_ALIYUN TEST_S3FS_QCLOUD S3ENDPOINT S3REGION S3APIKEY S3APISECRET S3BUCKET; do
-            if [ -z "${!name:-}" ]; then
-              missing+=("${name}")
-            fi
-          done
-          if [ "${#missing[@]}" -eq 0 ]; then
-            echo 'ready=true' >> "$GITHUB_OUTPUT"
-          else
-            echo 'ready=false' >> "$GITHUB_OUTPUT"
-            echo "::notice::UT coverage skipped because required secrets are unavailable: ${missing[*]}"
-          fi
       - id: eligibility
         name: Decide coverage eligibility
         env:
           IN_ORG: ${{ steps.check_in_org.outputs.in_org }}
           SAFE_LABEL: ${{ steps.check_safe_label.outputs.safe_label }}
-          SECRETS_READY: ${{ steps.check_coverage_secrets.outputs.ready }}
         run: |
           set -euo pipefail
-          if { [ "${IN_ORG}" = '1' ] || [ "${SAFE_LABEL}" = '1' ]; } && [ "${SECRETS_READY}" = 'true' ]; then
+          if [ "${IN_ORG}" = '1' ] || [ "${SAFE_LABEL}" = '1' ]; then
             echo 'allowed=true' >> "$GITHUB_OUTPUT"
           else
             echo 'allowed=false' >> "$GITHUB_OUTPUT"
@@ -132,9 +86,6 @@ jobs:
     needs: [check_coverage_eligibility]
     if: ${{ needs.check_coverage_eligibility.outputs.allowed == 'true' }}
     environment: ci
-    # Preserve the Guangzhou network path and capacity used by main's
-    # external Aliyun/QCloud coverage UT. This is intentionally larger than
-    # the UT-only minimum while we validate the external-storage timeout fix.
     runs-on: amd64-mo-guangzhou-2xlarge16
     timeout-minutes: 60
     steps:
@@ -167,13 +118,6 @@ jobs:
         run: |
           set -euo pipefail
           cd "$GITHUB_WORKSPACE"
-          export endpoint='${{ secrets.S3ENDPOINT }}'
-          export region='${{ secrets.S3REGION }}'
-          export apikey='${{ secrets.S3APIKEY }}'
-          export apisecret='${{ secrets.S3APISECRET }}'
-          export bucket='${{ secrets.S3BUCKET }}'
-          export TEST_S3FS_ALIYUN='${{ secrets.TEST_S3FS_ALIYUN }}'
-          export TEST_S3FS_QCLOUD='${{ secrets.TEST_S3FS_QCLOUD }}'
           coverage_profile="${RUNNER_TEMP}/ut-coverage.out"
           coverage_report="${RUNNER_TEMP}/ut-coverage-report.json"
           rm -f "${coverage_profile}" "${coverage_report}"
@@ -187,10 +131,9 @@ jobs:
           cgo_cflags="-I${GITHUB_WORKSPACE}/cgo -I${thirdparties_install_dir}/include"
           cgo_ldflags="-L${GITHUB_WORKSPACE}/cgo -lmo -L${thirdparties_install_dir}/lib -lusearch_c -Wl,-rpath,${thirdparties_install_dir}/lib -lm"
 
-          # Keep the same all-package coverage scope and external storage
-          # coverage as main. Save the verbose JSON report as an artifact
-          # rather than flooding the Actions console; the next step prints a
-          # concise parsed failure summary when this command fails.
+          # Keep the same all-package coverage scope. Save the verbose JSON
+          # report as an artifact rather than flooding the Actions console;
+          # the next step prints a concise parsed failure summary on failure.
           set +e
           CGO_CFLAGS="${cgo_cflags}" CGO_LDFLAGS="${cgo_ldflags}" \
             go test -mod=readonly -json -short -v -tags matrixone_test -p 6 \

--- a/.github/workflows/object-storage-integration.yaml
+++ b/.github/workflows/object-storage-integration.yaml
@@ -2,6 +2,17 @@ name: MatrixOne Object Storage Integration
 
 on:
   workflow_call:
+    inputs:
+      checkout_repository:
+        description: "Repository containing the MatrixOne revision to test"
+        required: false
+        type: string
+        default: ""
+      checkout_ref:
+        description: "MatrixOne commit or ref to test"
+        required: false
+        type: string
+        default: ""
     secrets:
       TOKEN_ACTION:
         description: "Token for checkout (e.g. pull from fork/private)"
@@ -28,6 +39,8 @@ jobs:
         with:
           token: ${{ secrets.TOKEN_ACTION }}
           fetch-depth: "1"
+          repository: ${{ inputs.checkout_repository || github.repository }}
+          ref: ${{ inputs.checkout_ref || github.sha }}
       - name: Set up Go
         uses: matrixorigin/CI/actions/setup-env@main
         with:

--- a/.github/workflows/object-storage-integration.yaml
+++ b/.github/workflows/object-storage-integration.yaml
@@ -1,0 +1,60 @@
+name: MatrixOne Object Storage Integration
+
+on:
+  workflow_call:
+    secrets:
+      TOKEN_ACTION:
+        description: "Token for checkout (e.g. pull from fork/private)"
+        required: false
+      TEST_S3FS_ALIYUN:
+        description: "Aliyun OSS integration test configuration"
+        required: true
+      TEST_S3FS_QCLOUD:
+        description: "Tencent COS integration test configuration"
+        required: true
+
+jobs:
+  object-storage-integration:
+    name: ${{ matrix.provider }} object storage integration
+    environment: ci
+    runs-on: amd64-mo-guangzhou-2xlarge16
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        provider: [aliyun, qcloud]
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          token: ${{ secrets.TOKEN_ACTION }}
+          fetch-depth: "1"
+      - name: Set up Go
+        uses: matrixorigin/CI/actions/setup-env@main
+        with:
+          go-version-file: "${{ github.workspace }}/go.mod"
+      - name: Run ${{ matrix.provider }} integration tests
+        env:
+          PROVIDER: ${{ matrix.provider }}
+          ALIYUN_TEST_SPEC: ${{ secrets.TEST_S3FS_ALIYUN }}
+          QCLOUD_TEST_SPEC: ${{ secrets.TEST_S3FS_QCLOUD }}
+          GOPROXY: http://goproxy.goproxy.svc.cluster.local,https://goproxy.cn,https://proxy.golang.org
+        run: |
+          set -euo pipefail
+          case "${PROVIDER}" in
+            aliyun)
+              test -n "${ALIYUN_TEST_SPEC}"
+              export TEST_S3FS_ALIYUN="${ALIYUN_TEST_SPEC}"
+              ;;
+            qcloud)
+              test -n "${QCLOUD_TEST_SPEC}"
+              export TEST_S3FS_QCLOUD="${QCLOUD_TEST_SPEC}"
+              ;;
+            *)
+              echo "unknown object storage provider: ${PROVIDER}" >&2
+              exit 1
+              ;;
+          esac
+          MO_RUN_EXTERNAL_OBJECT_STORAGE_TESTS=1 \
+            go test -mod=readonly -json -v ./pkg/fileservice \
+            -run '^Test(ObjectStoragesExternal|S3FSFromExternalSpecs)$' \
+            -count=1 -timeout=15m


### PR DESCRIPTION
## Summary

- remove real object-storage credentials from the all-package UT coverage job
- make coverage eligibility depend only on pull-request trust, not cloud secrets
- add a reusable provider-isolated Aliyun OSS / Tencent COS integration workflow
- allow trusted callers to test an exact MatrixOne PR repository and commit

## Root cause

The coverage job exported `TEST_S3FS_ALIYUN` and `TEST_S3FS_QCLOUD` before running `go test -short ./...`. MatrixOne's fileservice tests discovered those ambient variables and executed real cloud contract tests inside the unit-test process. A TCP timeout on the Tencent TKE runner's cross-cloud route to Aliyun OSS therefore failed an unrelated PR coverage check.

The failed run reached no HTTP response: DNS resolved, but TCP connection establishment to the Aliyun endpoint timed out. Its rerun passed on a different ephemeral runner at the same commit, which rules out credentials and MatrixOne SDK behavior as the direct cause.

## Changes

- coverage UT no longer declares, checks, or exports object-storage credentials
- stale generic S3 secret exports, which have no MatrixOne Go test consumers, are removed with the same boundary
- the external integration workflow runs Aliyun and QCloud independently with `fail-fast: false`
- each provider receives only its own test specification and explicitly enables MatrixOne's external test tier
- optional checkout repository/ref inputs let a trusted MatrixOne PR caller test the exact head commit before merge; scheduled callers default to their current repository revision

## Rollout

Merge this PR before the paired MatrixOne PR. The coverage change is independently compatible with current MatrixOne: without `TEST_S3FS_*`, the existing fileservice suite uses local disk only. After the caller lands, relevant fileservice/dependency PRs run real provider integration before merge, while a daily run continues detecting provider or network drift.

Related issue: matrixorigin/matrixone#26541.

## Validation

- `actionlint` v1.7.7 on both changed CI workflows and the paired MatrixOne caller; known custom-runner and existing `job.workflow_*` false positives excluded
- `git diff --check`
