### PR TITLE
ci: fix coverage deployment manifest order

### DIFF
--- a/.github/workflows/coverage-merge.yaml
+++ b/.github/workflows/coverage-merge.yaml
@@ -138,7 +138,7 @@ jobs:
             '
               length == 2
               and (map(.schema_version) == [1, 1])
-              and ((map(.deployment) | sort) == ["compose-proxy", "compose-pessimistic"])
+              and ((map(.deployment) | sort) == ["compose-pessimistic", "compose-proxy"])
               and ((map(.group) | sort) == [0, 1])
               and ((map(.generation) | unique | length) == 1)
               and ($expected_generation == "" or all(.[]; .generation == $expected_generation))


### PR DESCRIPTION
## What this PR fixes

The coverage merge workflow sorts the two BVT deployment names before comparing them, but the expected literal was in the opposite lexical order. Valid complementary manifests were therefore rejected after both multi-CN BVT jobs succeeded.

Observed in matrixorigin/matrixone#27080, run `31659940375`, attempt 2:

- `compose-proxy`, group 1
- `compose-pessimistic`, group 0
- matching generation and PR head SHA

`jq` sorts those names as `compose-pessimistic`, then `compose-proxy`. This PR corrects the expected order.

## Validation

- Replayed the exact deployment/group/generation/head values from the failed job: accepted.
- Duplicate deployment: rejected.
- Duplicate group: rejected.
- `actionlint` passed.
- YAML parsing and `git diff --check` passed.
