### PR TITLE
ci: canary Shanghai Go proxy for UT

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -122,14 +122,14 @@ jobs:
       - name: Configure Shanghai Go proxy
         if: ${{ contains(vars.UT_RUNNER_LABEL, 'shanghai') }}
         env:
-          SHANGHAI_GOPROXY: http://goproxy.goproxy.svc.cluster.local,https://goproxy.cn,direct
+          SHANGHAI_GOPROXY: http://goproxy.goproxy.svc.cluster.local|https://goproxy.cn|direct
         run: |
           set -euo pipefail
 
           echo "Runner: ${{ runner.name }}"
           echo "Runner OS: ${{ runner.os }}"
 
-          proxy_url="${SHANGHAI_GOPROXY%%,*}"
+          proxy_url="${SHANGHAI_GOPROXY%%|*}"
           proxy_host="${proxy_url#*://}"
           probe_module="github.com/spf13/cobra"
           probe_version="$(

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -119,11 +119,60 @@ jobs:
           echo "bucket=${{ secrets.S3BUCKET }}" >> $GITHUB_ENV
           # set ut workdir
           echo "UT_WORKDIR=${{ github.workspace }}" >> $GITHUB_ENV
+      - name: Configure Shanghai Go proxy
+        if: ${{ contains(vars.UT_RUNNER_LABEL, 'shanghai') }}
+        env:
+          SHANGHAI_GOPROXY: http://goproxy.goproxy.svc.cluster.local,https://goproxy.cn,direct
+        run: |
+          set -euo pipefail
+
+          echo "Runner: ${{ runner.name }}"
+          echo "Runner OS: ${{ runner.os }}"
+
+          proxy_url="${SHANGHAI_GOPROXY%%,*}"
+          proxy_host="${proxy_url#*://}"
+          probe_module="github.com/spf13/cobra"
+          probe_version="$(
+            awk -v module="$probe_module" '
+              $1 == module { print $2; exit }
+              $1 == "require" && $2 == module { print $3; exit }
+            ' go.mod 2>/dev/null || true
+          )"
+          proxy_status=""
+          proxy_enabled="false"
+          probe_result="not-attempted"
+
+          if [[ -z "$probe_version" ]]; then
+            probe_result="module-not-found-in-go.mod"
+          elif ! timeout 20s getent hosts "$proxy_host"; then
+            probe_result="dns-failed-or-timed-out"
+          elif proxy_status="$(curl \
+              --silent \
+              --show-error \
+              --connect-timeout 5 \
+              --max-time 30 \
+              --output /dev/null \
+              --write-out '%{http_code}' \
+              "${proxy_url}/${probe_module}/@v/${probe_version}.info")" && \
+            [[ "$proxy_status" == "200" ]]; then
+            proxy_enabled="true"
+            probe_result="module-http-200"
+            echo "Shanghai internal GOPROXY served ${probe_module}@${probe_version}"
+            echo "Using GOPROXY=${SHANGHAI_GOPROXY}"
+            echo "GOPROXY=${SHANGHAI_GOPROXY}" >> "$GITHUB_ENV"
+          else
+            probe_result="module-http-${proxy_status:-unavailable}"
+          fi
+
+          if [[ "$proxy_enabled" != "true" ]]; then
+            echo "::warning::Shanghai internal GOPROXY probe failed (${probe_result}); leaving GOPROXY unchanged"
+          fi
       - name: Unit Testing
         id: ut
         run: |
-          cd $GITHUB_WORKSPACE && make clean && make config
-          make ut UT_PARALLEL=${{ vars.UT_PARALLEL || 6 }} UT_TIMEOUT=${{ vars.UT_TIMEOUT || 40 }}
+          # Keep the explicit config and time it separately for the proxy canary.
+          cd $GITHUB_WORKSPACE && make clean && time make config
+          time make ut UT_PARALLEL=${{ vars.UT_PARALLEL || 6 }} UT_TIMEOUT=${{ vars.UT_TIMEOUT || 40 }}
       - name: Print Result(Old)
         if: ${{ always() }}
         continue-on-error: true


### PR DESCRIPTION
## Summary

- Probe the Shanghai internal Go module proxy before the Linux/x86 UT job.
- Enable an any-error fallback GOPROXY chain only when the Shanghai runner label is selected and the module endpoint responds successfully.
- Leave GOPROXY unchanged when DNS or HTTP probing fails.
- Time the existing make config and make ut commands without changing their exit behavior.

## Why

A recent MatrixOne run spent about 62 minutes in the first package-graph verification on the Shanghai UT runner. The Shanghai SCA job uses the internal module proxy and completed the comparable dependency phase much faster. This canary gathers direct evidence on the UT path while limiting the behavior change to Shanghai runners.

MatrixOne main deliberately uses pipe-separated public proxies so transient timeouts, connection failures, and 5xx responses can fall through. The canary preserves that resilience by exporting:

`http://goproxy.goproxy.svc.cluster.local|https://goproxy.cn|direct`

## Impact

- Shanghai UT probes the internal proxy with a 20-second DNS bound and a 30-second HTTP bound, then exports the fallback chain only after HTTP 200.
- A later error from the internal proxy falls through to goproxy.cn and then direct.
- Other runners retain the existing environment and Makefile proxy behavior; only shell timing output is added.
- Probe failures are warnings and do not fail or skip UT.

## Validation

- Parsed the workflow YAML with yq.
- Checked the modified run scripts with bash -n.
- Verified extraction of the first proxy URL from the pipe-separated chain.
- Ran git diff --check.
