### PR TITLE
ci: speed up SCA dependency checks with shared module cache

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -272,8 +272,9 @@ jobs:
     name: SCA Test on Linux/arm64
     env:
       # Keep dependency downloads on the Shanghai proxy for every SCA step,
-      # including the license dependency scan in `make static-check`.
-      GOPROXY: http://goproxy.goproxy.svc.cluster.local,https://goproxy.cn,direct
+      # including the license dependency scan in `make static-check`. Pipes
+      # preserve fallback when the internal proxy is unreachable or unhealthy.
+      GOPROXY: "http://goproxy.goproxy.svc.cluster.local|https://goproxy.cn|direct"
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -295,6 +296,11 @@ jobs:
           setup-java: false
           setup-cmake: true
           go-version-file: "${{ github.workspace }}/go.mod"
+      - name: Restore golangci-lint cache
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: ~/.cache/golangci-lint
+          key: golangci-lint-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('go.mod', 'go.sum', '.golangci.yml', 'Makefile') }}
       - name: Prepare ENV
         run: |
           set -euo pipefail

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -297,15 +297,34 @@ jobs:
       - name: Resolve Go module cache metadata
         id: go-module-cache-metadata
         run: |
-          echo "path=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+          cache_dir="$GITHUB_WORKSPACE/.sca-go-module-cache"
+          # Self-hosted runner workspaces can outlive a job. Start from only the
+          # trusted cache archive, not files left by a previous PR.
+          GOMODCACHE="$cache_dir" go clean -modcache
+          echo "GOMODCACHE=$cache_dir" >> "$GITHUB_ENV"
           echo "version=$(go env GOVERSION)" >> "$GITHUB_OUTPUT"
       - name: Restore Go module cache
         uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
-          path: ${{ steps.go-module-cache-metadata.outputs.path }}
+          # A relative path keeps both the hidden cache version and tar entries
+          # identical to the trusted producer across different runner layouts.
+          path: .sca-go-module-cache
           key: matrixone-go-mod-${{ runner.os }}-${{ runner.arch }}-${{ steps.go-module-cache-metadata.outputs.version }}-${{ hashFiles('go.mod', 'go.sum') }}
           restore-keys: |
             matrixone-go-mod-${{ runner.os }}-${{ runner.arch }}-${{ steps.go-module-cache-metadata.outputs.version }}-
+      - name: Move Go module cache out of the source tree
+        run: |
+          set -euo pipefail
+          staging_dir="$GOMODCACHE"
+          runtime_root=$(mktemp -d "${RUNNER_TEMP%/}/matrixone-go-mod.XXXXXX")
+          runtime_dir="$runtime_root/cache"
+          if [ -d "$staging_dir" ]; then
+            mv "$staging_dir" "$runtime_dir"
+          else
+            mkdir "$runtime_dir"
+          fi
+          echo "GOMODCACHE=$runtime_dir" >> "$GITHUB_ENV"
       - name: Prepare ENV
         run: |
           set -euo pipefail

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -270,11 +270,6 @@ jobs:
     # explicit escape hatch for a larger runner.
     runs-on: ${{ vars.SCA_RUNNER_LABEL || 'arm64-mo-shanghai-4c8g' }}
     name: SCA Test on Linux/arm64
-    env:
-      # Keep dependency downloads on the Shanghai proxy for every SCA step,
-      # including the license dependency scan in `make static-check`. Pipes
-      # preserve fallback when the internal proxy is unreachable or unhealthy.
-      GOPROXY: "http://goproxy.goproxy.svc.cluster.local|https://goproxy.cn|direct"
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -289,18 +284,28 @@ jobs:
           yamlFiles: |
             .github/ISSUE_TEMPLATE/*.yml
             .github/ISSUE_TEMPLATE/*.yaml
+      - name: Configure Shanghai Go proxy
+        if: ${{ !vars.SCA_RUNNER_LABEL || contains(vars.SCA_RUNNER_LABEL, 'shanghai') }}
+        run: |
+          echo "GOPROXY=http://goproxy.goproxy.svc.cluster.local|https://goproxy.cn|direct" >> "$GITHUB_ENV"
       - name: Set up Go
         uses: matrixorigin/CI/actions/setup-env@main
         with:
-          cache: true
           setup-java: false
           setup-cmake: true
           go-version-file: "${{ github.workspace }}/go.mod"
-      - name: Restore golangci-lint cache
-        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      - name: Resolve Go module cache metadata
+        id: go-module-cache-metadata
+        run: |
+          echo "path=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
+          echo "version=$(go env GOVERSION)" >> "$GITHUB_OUTPUT"
+      - name: Restore Go module cache
+        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
-          path: ~/.cache/golangci-lint
-          key: golangci-lint-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('go.mod', 'go.sum', '.golangci.yml', 'Makefile') }}
+          path: ${{ steps.go-module-cache-metadata.outputs.path }}
+          key: matrixone-go-mod-${{ runner.os }}-${{ runner.arch }}-${{ steps.go-module-cache-metadata.outputs.version }}-${{ hashFiles('go.mod', 'go.sum') }}
+          restore-keys: |
+            matrixone-go-mod-${{ runner.os }}-${{ runner.arch }}-${{ steps.go-module-cache-metadata.outputs.version }}-
       - name: Prepare ENV
         run: |
           set -euo pipefail

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -270,6 +270,10 @@ jobs:
     # explicit escape hatch for a larger runner.
     runs-on: ${{ vars.SCA_RUNNER_LABEL || 'arm64-mo-shanghai-4c8g' }}
     name: SCA Test on Linux/arm64
+    env:
+      # Keep dependency downloads on the Shanghai proxy for every SCA step,
+      # including the license dependency scan in `make static-check`.
+      GOPROXY: http://goproxy.goproxy.svc.cluster.local,https://goproxy.cn,direct
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -287,12 +291,11 @@ jobs:
       - name: Set up Go
         uses: matrixorigin/CI/actions/setup-env@main
         with:
+          cache: true
           setup-java: false
           setup-cmake: true
           go-version-file: "${{ github.workspace }}/go.mod"
       - name: Prepare ENV
-        env:
-          GOPROXY: http://goproxy.goproxy.svc.cluster.local,https://goproxy.cn,direct
         run: |
           set -euo pipefail
           cd "$GITHUB_WORKSPACE"


### PR DESCRIPTION
## Summary

- configure the Shanghai GOPROXY for all SCA steps only when the selected runner is the default or has a Shanghai label
- use pipe-separated GOPROXY fallback so DNS, connection, and 5xx failures can fall through
- restore the shared MatrixOne Go module cache with the restore-only cache action
- keep pull_request_target runs unable to save or overwrite shared caches

## Cache lifecycle

The cache belongs to the calling matrixorigin/matrixone repository, not this reusable-workflow repository.

- trusted producer: matrixorigin/matrixone#27128 runs on main push, schedule, or workflow_dispatch
- PR consumer: this reusable workflow restores only
- exact key: OS, architecture, Go version, and go.mod/go.sum hash
- dependency-changing PRs restore the latest same-platform/main cache through restore-keys and download only the delta
- after the dependency change merges, the trusted producer writes the new exact main cache

Producer and consumer use the same relative staging path and key algorithm. The relative path keeps both the actions/cache hidden version and archive entries portable across runner layouts. The consumer moves the restored module cache into RUNNER_TEMP before static checks so license-eye does not enumerate cached dependency sources.

## Why

A recent MatrixOne SCA run spent about 85 minutes in make static-check, including 64m16s in license-eye dep check. That check repeats Go module downloads. The previous GOPROXY was scoped only to Prepare ENV and no cross-PR MatrixOne main cache existed.

With an existing module cache, license-eye dep check completes in about 0.6 seconds. No SCA validation is skipped.

## Validation

- YAML syntax parsed successfully
- actionlint reports only the two unchanged findings already present on main
- producer/consumer path, key, and restore prefix match mechanically
- cache cleanup and relocation lifecycle simulated successfully
- git diff --check passed

Related producer: https://github.com/matrixorigin/matrixone/pull/27128
