### PR TITLE
ci: disable provenance attestations on image pushes — ACR rejects them

### DIFF
--- a/.github/workflows/image-build.yaml
+++ b/.github/workflows/image-build.yaml
@@ -133,6 +133,11 @@ jobs:
             type=registry,ref=${{ steps.prep.outputs.cache_repo }}
             type=registry,ref=${{ steps.prep.outputs.legacy_cache_repo }}
           cache-to: type=registry,ref=${{ steps.prep.outputs.cache_repo }},mode=max
+          # Aliyun ACR rejects OCI attestation manifests
+          # (application/vnd.oci.empty.v1+json); without this every ACR push
+          # fails with "denied: unknown manifest class".
+          provenance: false
+          sbom: false
 
   manifest:
     name: Publish multi-arch manifests
@@ -286,4 +291,8 @@ jobs:
           tags: |
             ${{ steps.prep.outputs.tag }}
             ${{ steps.prep.outputs.acr_tag }}
+          # Aliyun ACR rejects OCI attestation manifests; see the product
+          # build step above.
+          provenance: false
+          sbom: false
 


### PR DESCRIPTION
## What this PR does / why we need it:

The nightly "Build and Push Images" runs have been failing on both architectures (e.g. runs 31749181599 from the 2026-08-13 cron — predating #418 — and yesterday's dispatch 31826694057) with:

```
denied: unknown manifest class for application/vnd.oci.empty.v1+json
```

on the ACR push. Aliyun ACR rejects the OCI attestation manifests that buildx now attaches by default. This sets `provenance: false` / `sbom: false` on both push steps — the product image build and the new `ci-builder` job (which pushes to the same ACR mirror and would fail identically on its first real publish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)